### PR TITLE
Fix SuperApp Payment. Change amount parameter from int to double

### DIFF
--- a/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/PaymentsApi.kt
+++ b/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/PaymentsApi.kt
@@ -20,13 +20,13 @@ import kotlinx.coroutines.launch
 
 class PaymentsApi(action: ApiAction?) : ExternalApi(action) {
     private val methodPayWithoutUI = IMethodInvoker { parameters: List<Any> ->
-        val amount = parameters[0].toString().toInt()
+        val amount = parameters[0].toString().toDouble()
         val paymentId = PaymentsService.pay(amount)
         ExternalApiResult.success(paymentId)
     }
     private val methodPayWithUI: IMethodInvokerWithActivityResult = object : IMethodInvokerWithActivityResult {
         override fun invoke(parameters: List<Any>): ExternalApiResult {
-            val amount = parameters[0].toString().toInt()
+            val amount = parameters[0].toString().toDouble()
             startActivityForResult(PaymentActivity.newIntent(context, amount), PAYMENT_REQUEST_CODE)
             return ExternalApiResult.SUCCESS_WAIT
         }

--- a/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/services/PaymentsService.kt
+++ b/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/services/PaymentsService.kt
@@ -12,7 +12,7 @@ object PaymentsService {
     private const val SDT_PAYMENT_INFORMATION_ITEM_AFFINITY = "affinity"
     private const val SDT_PAYMENT_INFORMATION_ITEM_TYPE = "type"
 
-    fun pay(amount: Int): String {
+    fun pay(amount: Double): String {
         return amount.toString() + "-" + UUID.randomUUID().toString()
     }
 

--- a/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/ui/BottomSheet.kt
+++ b/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/ui/BottomSheet.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun BottomSheet(@PreviewParameter(AmountProvider::class) amount: Int, succeeded: () -> Unit, canceled: () -> Unit) {
+fun BottomSheet(@PreviewParameter(AmountProvider::class) amount: Double, succeeded: () -> Unit, canceled: () -> Unit) {
     Surface(
         modifier = Modifier
             .fillMaxWidth()

--- a/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/ui/PaymentActivity.kt
+++ b/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/ui/PaymentActivity.kt
@@ -12,7 +12,7 @@ import com.genexus.superapps.bankx.payments.ui.theme.BankingSuperAppTheme
 class PaymentActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val amount = intent.extras?.getInt(EXTRA_AMOUNT) ?: 0
+        val amount : Double = intent.extras?.getDouble(EXTRA_AMOUNT) ?: 0.0
         setContent {
             BankingSuperAppTheme {
                 PaymentSheet({ canceled() }) {
@@ -27,7 +27,7 @@ class PaymentActivity : ComponentActivity() {
         finish()
     }
 
-    private fun succeeded(amount: Int) {
+    private fun succeeded(amount: Double) {
         val paymentId = PaymentsService.pay(amount)
         val result = Intent().apply { putExtra(EXTRA_PAYMENT_ID, paymentId) }
         setResult(Activity.RESULT_OK, result)
@@ -38,7 +38,7 @@ class PaymentActivity : ComponentActivity() {
         private const val EXTRA_AMOUNT = "Amount"
         const val EXTRA_PAYMENT_ID = "PaymentId"
 
-        fun newIntent(context: Context?, amount: Int): Intent {
+        fun newIntent(context: Context?, amount: Double): Intent {
             val intent = Intent(context, PaymentActivity::class.java)
             intent.putExtra(EXTRA_AMOUNT, amount)
             return intent


### PR DESCRIPTION
Change de Payment API example to accept double instead of int at the "amount" parameter.
